### PR TITLE
fix: prevent data from being imported twice due to overlapping data

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -191,11 +191,17 @@ export function startSynchronization({
 } & SyncDiasendDataToNightScoutArgs = {}) {
   let nextDateFrom: Date = dateFrom;
   syncDiasendDataToNightscout({ dateFrom, ...syncArgs })
-    .then(([records]) => {
-      if (records && records.length) {
-        // next run's data should be fetched where this run ended, so take a look at the records
-        nextDateFrom = new Date(records[records.length - 1].date + 1000);
+    .then(([entries, treatments]) => {
+      // next run's data should be fetched where this run ended, so take a look at the records
+      if (!entries?.length && !treatments?.length) {
+        return;
       }
+      nextDateFrom = new Date(
+        (entries ?? [])
+          .map((e) => e.date)
+          .concat((treatments ?? []).map((t) => t.date))
+          .sort((a, b) => b - a)[0] + 1000
+      );
     })
     .finally(() => {
       // schedule the next run


### PR DESCRIPTION
In its current state, it can happen that some treatments are imported more than once as we only check the latest entry (i.e. glucose value) to determine from when to start the next polling session. Therefore it can happen, that a treatment is processed twice.

This PR fixes this by also taking into account treatments and starting after the last treatment or glucose value.