### PR TITLE
feat: scrape basal rate from diasend website

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,9 +1,8 @@
 name: "Continuous integration"
 
 on:
-  on:
-    - push
-    - pull_request
+  - push
+  - pull_request
 
 jobs:
   build:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,4 @@
-name: Continuous integration
+name: "Continuous integration"
 
 on:
   on:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,18 @@
+name: Continuous integration
+
+on:
+  on:
+    - push
+    - pull_request
+
+jobs:
+  build:
+    name: Test & Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      # install npm dependencies
+      - run: yarn install --frozen-lockfile
+      - run: yarn test
+      - run: yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release workflow
+name: Release
 
 on:
   push:

--- a/@custom-types/rand-user-agent.d.ts
+++ b/@custom-types/rand-user-agent.d.ts
@@ -1,0 +1,1 @@
+declare module "rand-user-agent";

--- a/__tests__/diasend-to-nightscout-entries.ts
+++ b/__tests__/diasend-to-nightscout-entries.ts
@@ -12,19 +12,6 @@ const testDevice: DeviceData = {
 };
 
 describe("testing conversion of diasend patient data to nightscout entries", () => {
-  const ORIGINAL_TZ = process.env.TZ;
-
-  beforeEach(() => {
-    // set the timezone explicitly to avoid any conversion issues of non-timezone aware diasend dates
-    jest.resetModules();
-    process.env.TZ = "Europe/Berlin";
-  });
-
-  afterAll(() => {
-    // restore original timezone
-    process.env.TZ = ORIGINAL_TZ;
-  });
-
   test("continuous reading", () => {
     // given a continuous glucose reading from diasend
     const glucoseReading: GlucoseRecord = {

--- a/__tests__/diasend-to-nightscout-treatments.ts
+++ b/__tests__/diasend-to-nightscout-treatments.ts
@@ -1,13 +1,6 @@
-import {
-  diasendBolusRecordToNightscoutTreatment,
-  diasendGlucoseRecordToNightscoutEntry,
-} from "../adapter";
-import { BolusRecord, CarbRecord, DeviceData, GlucoseRecord } from "../diasend";
-import {
-  CorrectionBolusTreatment,
-  MealBolusTreatment,
-  SensorGlucoseValueEntry,
-} from "../nightscout";
+import { diasendBolusRecordToNightscoutTreatment } from "../adapter";
+import { BolusRecord, CarbRecord, DeviceData } from "../diasend";
+import { CorrectionBolusTreatment, MealBolusTreatment } from "../nightscout";
 
 const testDevice: DeviceData = {
   manufacturer: "ACME",
@@ -16,19 +9,6 @@ const testDevice: DeviceData = {
 };
 
 describe("testing conversion of diasend patient data to nightscout treatments", () => {
-  const ORIGINAL_TZ = process.env.TZ;
-
-  beforeEach(() => {
-    // set the timezone explicitly to avoid any conversion issues of non-timezone aware diasend dates
-    jest.resetModules();
-    process.env.TZ = "Europe/Berlin";
-  });
-
-  afterAll(() => {
-    // restore original timezone
-    process.env.TZ = ORIGINAL_TZ;
-  });
-
   test("meal bolus + carbs", () => {
     // given a meal bolus and matching carb record
     const mealBolusRecord: BolusRecord = {

--- a/config.ts
+++ b/config.ts
@@ -8,6 +8,7 @@ const config: {
   nightscout: {
     url?: string;
     apiSecret?: string;
+    profileName?: string;
   };
 } = {
   diasend: {
@@ -22,6 +23,7 @@ const config: {
   nightscout: {
     url: process.env.NIGHTSCOUT_URL,
     apiSecret: process.env.NIGHTSCOUT_API_SECRET,
+    profileName: process.env.NIGHTSCOUT_PROFILE_NAME,
   },
 };
 

--- a/diasend.ts
+++ b/diasend.ts
@@ -178,7 +178,7 @@ export async function getAuthenticatedScrapingClient({
   }
 }
 
-interface PumpSettings {
+export interface PumpSettings {
   basalProfile: [string, number][];
   insulinCarbRatioProfile: [string, number][];
   insulinSensitivityProfile: [string, number][];

--- a/diasend.ts
+++ b/diasend.ts
@@ -1,9 +1,13 @@
-import axios from "axios";
+import axios, { AxiosError, AxiosInstance } from "axios";
 import config from "./config";
 import { stringify } from "querystring";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import NodeCache from "node-cache";
+import { wrapper } from "axios-cookiejar-support";
+import { CookieJar } from "tough-cookie";
+import randUserAgent from "rand-user-agent";
+import { load } from "cheerio";
 
 type GlucoseUnit = "mg/dl" | "mmol/l";
 
@@ -122,4 +126,85 @@ export async function getPatientData(
   );
 
   return response.data;
+}
+
+// SCRAPER for website
+const diasendWebsiteBaseUrl = "https://international.diasend.com/";
+
+export async function getAuthenticatedScrapingClient({
+  username,
+  password,
+  country = 108,
+  locale = "en_US",
+}: {
+  username: string;
+  password: string;
+  country?: number;
+  locale?: string;
+}) {
+  const client = wrapper(
+    axios.create({
+      baseURL: diasendWebsiteBaseUrl,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+      jar: new CookieJar(),
+      // use a random user agent to scracpe
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      headers: { "User-Agent": randUserAgent() as string },
+    })
+  );
+  try {
+    await client.post(
+      "/diasend/includes/account/login.php",
+      stringify({ country, locale, user: username, passwd: password }),
+      {
+        // withCredentials: true,
+        // we don't want the actual redirect to the dashboard to happen (as it wouldn't have cookies set)
+        maxRedirects: 0,
+      }
+    );
+    throw new Error('Login request cannot be "successful"');
+  } catch (err) {
+    const redirectResponse = (err as AxiosError).response;
+    const userId = redirectResponse?.headers["location"].match(
+      /\/reports\/(?<userId>.*)\/summary/
+    )?.groups?.userId;
+    if (!userId) {
+      throw new Error("Could not find userId to scrape diasend");
+    }
+
+    // remember the PHPSESSID (to authenticate future requests) --> done automatically by the cookiejar
+    // and the "userId" which can be obtained from the redirect happening after login and is required to access reports etc.
+    return { client, userId };
+  }
+}
+
+export async function getPumpSettings(client: AxiosInstance, userId: string) {
+  const { data } = await client.get<string>(
+    `/reports/${userId}/insulin/pump-settings`
+  );
+  const $ = load(data);
+  // find the active basal profile
+  const activeBasalProfile = $("td")
+    .filter((_, ele) => $(ele).text() === "Active basal program")
+    .next()
+    .text();
+  const basalProfile: [string, number][] = (
+    $("h4")
+      .filter((_, e) =>
+        $(e).text().startsWith(`Program: ${activeBasalProfile}`)
+      )
+      .next("table")
+      // get all rows except for header row
+      .find("tr:not(:first)")
+      .map((_, row) =>
+        $(row)
+          // get all cells of a row
+          .children("td")
+          // take only the last two cells (start time and rate)
+          .slice(-2)
+          .map((_, cell) => $(cell).text())
+      )
+      .get() as [string, string][]
+  ).map(([startTime, rate]) => [startTime, parseFloat(rate)]);
+  return basalProfile;
 }

--- a/index.ts
+++ b/index.ts
@@ -7,21 +7,26 @@ import {
   GlucoseRecord,
   CarbRecord,
   BolusRecord,
-  DeviceData,
+  getPumpSettings,
+  getAuthenticatedScrapingClient,
+  PumpSettings,
 } from "./diasend";
 import {
-  SensorGlucoseValueEntry,
   reportEntriesToNightscout,
   MealBolusTreatment,
   reportTreatmentsToNightscout,
   Treatment,
   CorrectionBolusTreatment,
-  ManualGlucoseValueEntry,
   Entry,
+  Profile,
+  fetchProfile,
+  updateProfile,
+  TimeBasedValue,
 } from "./nightscout";
 import {
   diasendBolusRecordToNightscoutTreatment,
   diasendGlucoseRecordToNightscoutEntry,
+  diasendPumpSettingsToNightscoutProfile,
 } from "./adapter";
 
 dayjs.extend(relativeTime);
@@ -164,15 +169,15 @@ export function startSynchronization({
       );
     })
     .finally(() => {
-      // schedule the next run
-      console.log(
-        `Next run will be in ${dayjs()
-          .add(pollingIntervalMs, "milliseconds")
-          .fromNow()}...`
-      );
       // if synchronizationTimeoutId is set to 0 when we get here, don't schedule a re-run. This is the exit condition
       // and prevents the synchronization loop from continuing if the timeout is cleared while already running the sync
       if (synchronizationTimeoutId !== 0) {
+        // schedule the next run
+        console.log(
+          `Next run will be in ${dayjs()
+            .add(pollingIntervalMs, "milliseconds")
+            .fromNow()}...`
+        );
         synchronizationTimeoutId = setTimeout(() => {
           void startSynchronization({
             pollingIntervalMs,
@@ -187,4 +192,84 @@ export function startSynchronization({
   return () => {
     clearTimeout(synchronizationTimeoutId);
   };
+}
+
+let pumpSettingsSynchronizationTimeoutId: NodeJS.Timeout | undefined | number;
+
+export function startPumpSettingsSynchronization({
+  diasendUsername = config.diasend.username,
+  diasendPassword = config.diasend.password,
+  // per default synchronize every 12 hours
+  pollingIntervalMs = 12 * 3600 * 1000,
+  nightscoutProfileName = config.nightscout.profileName,
+  nightscoutPumpSettingsHandler = (pumpSettings) =>
+    savePumpSettingsInNightscoutProfile(nightscoutProfileName!, pumpSettings),
+}: {
+  diasendUsername?: string;
+  diasendPassword?: string;
+  pollingIntervalMs?: number;
+  nightscoutProfileName?: string;
+  nightscoutPumpSettingsHandler?: (
+    pumpSettings: PumpSettings
+  ) => Promise<Profile>;
+} = {}) {
+  function pumpSynchronizationLoop() {
+    if (!diasendUsername) {
+      throw Error("Diasend Username not configured");
+    }
+    if (!diasendPassword) {
+      throw Error("Diasend Password not configured");
+    }
+
+    if (!nightscoutProfileName) {
+      console.info(
+        "Not synchronizing pump settings to nightscout profile since profile name is not defined"
+      );
+      return;
+    }
+
+    getAuthenticatedScrapingClient({
+      username: diasendUsername,
+      password: diasendPassword,
+    })
+      .then(({ client, userId }) => getPumpSettings(client, userId))
+      .then(nightscoutPumpSettingsHandler)
+      .finally(() => {
+        // restart after specified time
+        // if synchronizationTimeoutId is set to 0 when we get here, don't schedule a re-run. This is the exit condition
+        // and prevents the synchronization loop from continuing if the timeout is cleared while already running the sync
+        if (pumpSettingsSynchronizationTimeoutId !== 0) {
+          console.log(
+            `Next run to synchronize pump settings will be in ${dayjs()
+              .add(pollingIntervalMs, "milliseconds")
+              .fromNow()}...`
+          );
+
+          setTimeout(pumpSynchronizationLoop, pollingIntervalMs);
+        }
+      });
+  }
+
+  void pumpSynchronizationLoop();
+
+  // return a function that can be used to end the loop
+  return () => {
+    clearTimeout(pumpSettingsSynchronizationTimeoutId);
+  };
+}
+
+async function savePumpSettingsInNightscoutProfile(
+  nightscoutProfileName: string,
+  pumpSettings: PumpSettings
+): Promise<Profile> {
+  const profile = await fetchProfile();
+
+  return await updateProfile({
+    ...profile,
+    store: {
+      ...profile.store,
+      [nightscoutProfileName]:
+        diasendPumpSettingsToNightscoutProfile(pumpSettings),
+    },
+  });
 }

--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,6 @@ import {
   Profile,
   fetchProfile,
   updateProfile,
-  TimeBasedValue,
 } from "./nightscout";
 import {
   diasendBolusRecordToNightscoutTreatment,

--- a/nightscout.ts
+++ b/nightscout.ts
@@ -74,8 +74,6 @@ export interface CorrectionBolusTreatment extends BaseBolusTreatment {
   eventType: "Correction Bolus";
 }
 
-export interface BGCheckTreatment extends Treatment {}
-
 export interface MealBolusTreatment extends BaseBolusTreatment {
   eventType: "Meal Bolus";
   // Amount of carbs given.

--- a/nightscout.ts
+++ b/nightscout.ts
@@ -132,3 +132,46 @@ export async function reportTreatmentsToNightscout(values: Treatment[]) {
   );
   return response.data;
 }
+
+export interface TimeBasedValue {
+  time: string;
+  timeAsSeconds?: number;
+  value: number;
+}
+
+export interface ProfileConfig {
+  dia: number;
+  carbratio: TimeBasedValue[];
+  sens: TimeBasedValue[];
+  basal: TimeBasedValue[];
+  target_low: TimeBasedValue[];
+  target_high: TimeBasedValue[];
+  startDate?: string;
+  timezone?: string;
+  carbs_hr?: number;
+  delay?: number;
+  units?: "mg/dl" | "mmol/l";
+}
+
+export interface Profile {
+  defaultProfile: string;
+  store: { [profileName: string]: ProfileConfig };
+}
+
+export async function fetchProfile(): Promise<Profile> {
+  const { data } = await getNightscoutClient().get<Profile[]>(
+    "/api/v1/profile"
+  );
+
+  // active profile is always first of profiles
+  return data[0];
+}
+
+export async function updateProfile(profile: Profile): Promise<Profile> {
+  const { data } = await getNightscoutClient().put<Profile>(
+    "/api/v1/profile",
+    profile
+  );
+
+  return data;
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "tsc",
     "prepare": "npm run build",
     "run": "yarn build && node dist/run.js",
-    "test": "jest"
+    "test": "cross-env TZ=Europe/Berlin jest"
   },
   "engines": {
     "node": ">=14"
@@ -26,8 +26,10 @@
     "@types/tough-cookie": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",
+    "cross-env": "^7.0.3",
     "eslint": "^8.21.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "jest": "^28",
     "prettier": "^2.7.1",
     "ts-jest": "^28.0.8",
@@ -48,7 +50,8 @@
     ],
     "parser": "@typescript-eslint/parser",
     "plugins": [
-      "@typescript-eslint"
+      "@typescript-eslint",
+      "unused-imports"
     ],
     "ignorePatterns": [
       "dist/**"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
-    "axios-cookiejar-support": "^4.0.3",
+    "axios-cookiejar-support": "^2",
     "cheerio": "^1.0.0-rc.12",
     "dayjs": "^1.11.4",
     "node-cache": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,14 @@
     "run": "yarn build && node dist/run.js",
     "test": "jest"
   },
+  "engines": {
+    "node": ">=14"
+  },
   "devDependencies": {
+    "@types/cheerio": "^0.22.31",
     "@types/jest": "^28.1.8",
     "@types/node": "^18.7.7",
+    "@types/tough-cookie": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",
     "eslint": "^8.21.0",
@@ -52,8 +57,12 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
+    "axios-cookiejar-support": "^4.0.3",
+    "cheerio": "^1.0.0-rc.12",
     "dayjs": "^1.11.4",
-    "node-cache": "^5.1.2"
+    "node-cache": "^5.1.2",
+    "rand-user-agent": "^1.0.78",
+    "tough-cookie": "^4.1.2"
   },
   "keywords": [
     "nightscout",

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ The following environment variables are required, also see [example.env](./.env.
 Optionally, you can also provide the following values:
 
 - `TZ`: the timezone from which the glucose values have been sent to diasend. If you run this project on your local machine, this configuration will likely not be necessary. If your run it on a dedicated server, though it must be configured to avoid an [offset in the data due to timezone issues]. Usually the timezone in which your device exporting data to diasend is.
+- `NIGHTSCOUT_PROFILE_NAME`: The name of the profile in nightscout to which to synchronize the diasend pump settings. Defaults to undefined which means the pump settings will not be synchronized. When set, the specified profile will be overwritten with the settings from diasend so be careful.
 - `DIASEND_CLIENT_ID`: client id for authorization against diasend. Defaults to `a486o3nvdu88cg0sos4cw8cccc0o0cg.api.diasend.com`
 - `DIASEND_CLIENT_SECRET`: client secret for authorization against diasend. Defaults to `8imoieg4pyos04s44okoooowkogsco4`
 

--- a/readme.md
+++ b/readme.md
@@ -6,11 +6,11 @@ While diasend will eventually be replaced by glooko which will provide a more op
 
 ## Supported Features / Data
 
-- ✅ Glucose Values (CGM)
-- ✅ Correction and Meal Boli
-- ❌ Calibrations
-- ❌ Basal rates
-- ❌ Pump settings (see [open issue][pump-settings-issue])
+✅ Glucose Values (CGM) <br />
+✅ Correction and Meal Boli <br />
+✅ Basal rates <br />
+✅ Pump settings (see [issue][pump-settings-issue])
+
 
 ## Configuration
 

--- a/run.ts
+++ b/run.ts
@@ -1,3 +1,4 @@
-import { startSynchronization } from ".";
+import { startPumpSettingsSynchronization, startSynchronization } from ".";
 
-void startSynchronization();
+startSynchronization();
+startPumpSettingsSynchronization();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,11 @@
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "node", /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    "paths": {
+      "*": [
+        "./@custom-types/*"
+      ]
+    }, /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,12 +942,12 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios-cookiejar-support@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/axios-cookiejar-support/-/axios-cookiejar-support-4.0.3.tgz#c906029d76c7c185224ab00f97c64ce5e241ac4f"
-  integrity sha512-fMQc0mPR1CikWZEwVC6Av+sD4cJuV2eo06HFA+DfhY54uRcO43ILGxaq7YAMTiM0V0SdJCV4NhE1bOsQYlfSkg==
+axios-cookiejar-support@^2:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/axios-cookiejar-support/-/axios-cookiejar-support-2.0.5.tgz#f8370c41de34aaa5b482b5d9d6439fd535b1c4d3"
+  integrity sha512-y5S8feB6SbITWEiisCqFzQWaob+M34vVz8sP5KmQTDovM7HJ8xG9KQIETh0bFRyXUfDzWR5aPzfgkTND0wuYvQ==
   dependencies:
-    http-cookie-agent "^4.0.2"
+    http-cookie-agent "^1.0.6"
 
 axios@^0.27.2:
   version "0.27.2"
@@ -1788,10 +1788,10 @@ htmlparser2@^8.0.1:
     domutils "^3.0.1"
     entities "^4.3.0"
 
-http-cookie-agent@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/http-cookie-agent/-/http-cookie-agent-4.0.2.tgz#dcdaae18ed1f7452d81ae4d5cd80b227d6831b69"
-  integrity sha512-noTmxdH5CuytTnLj/Qv3Z84e/YFq8yLXAw3pqIYZ25Edhb9pQErIAC+ednw40Cic6Le/h9ryph5/TqsvkOaUCw==
+http-cookie-agent@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/http-cookie-agent/-/http-cookie-agent-1.0.6.tgz#4d11436be06e4b2e00ee2e729a2abd79d969e639"
+  integrity sha512-Ei0BDjMfy6MSXATmCZ5nWr935NLYl6eD/BTxVGOIrKAlg4xDtMdk+8a+caq6Qwa4FACn+vACj89pFKlXmHOnkQ==
   dependencies:
     agent-base "^6.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -681,6 +681,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cheerio@^0.22.31":
+  version "0.22.31"
+  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.31.tgz#b8538100653d6bb1b08a1e46dec75b4f2a5d5eb6"
+  integrity sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -739,6 +746,11 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/tough-cookie@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
+  integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -847,6 +859,13 @@ acorn@^8.4.1, acorn@^8.8.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
+agent-base@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -923,6 +942,13 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+axios-cookiejar-support@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/axios-cookiejar-support/-/axios-cookiejar-support-4.0.3.tgz#c906029d76c7c185224ab00f97c64ce5e241ac4f"
+  integrity sha512-fMQc0mPR1CikWZEwVC6Av+sD4cJuV2eo06HFA+DfhY54uRcO43ILGxaq7YAMTiM0V0SdJCV4NhE1bOsQYlfSkg==
+  dependencies:
+    http-cookie-agent "^4.0.2"
+
 axios@^0.27.2:
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
@@ -995,6 +1021,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1081,6 +1112,31 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+cheerio-select@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-2.1.0.tgz#4d8673286b8126ca2a8e42740d5e3c4884ae21b4"
+  integrity sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==
+  dependencies:
+    boolbase "^1.0.0"
+    css-select "^5.1.0"
+    css-what "^6.1.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+
+cheerio@^1.0.0-rc.12:
+  version "1.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.12.tgz#788bf7466506b1c6bf5fae51d24a2c4d62e47683"
+  integrity sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==
+  dependencies:
+    cheerio-select "^2.1.0"
+    dom-serializer "^2.0.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    htmlparser2 "^8.0.1"
+    parse5 "^7.0.0"
+    parse5-htmlparser2-tree-adapter "^7.0.0"
 
 ci-info@^3.2.0:
   version "3.3.2"
@@ -1173,12 +1229,28 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+
 dayjs@^1.11.4:
   version "1.11.4"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.4.tgz#3b3c10ca378140d8917e06ebc13a4922af4f433e"
   integrity sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g==
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1234,6 +1306,36 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
+  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.1"
+
 electron-to-chromium@^1.4.202:
   version "1.4.232"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.232.tgz#67a0a874b0057662244230d18d3a9847c135a9d9"
@@ -1248,6 +1350,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+entities@^4.2.0, entities@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.3.1.tgz#c34062a94c865c322f9d67b4384e4169bcede6a4"
+  integrity sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1651,6 +1758,23 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+htmlparser2@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.1.tgz#abaa985474fcefe269bc761a779b544d7196d010"
+  integrity sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    entities "^4.3.0"
+
+http-cookie-agent@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/http-cookie-agent/-/http-cookie-agent-4.0.2.tgz#dcdaae18ed1f7452d81ae4d5cd80b227d6831b69"
+  integrity sha512-noTmxdH5CuytTnLj/Qv3Z84e/YFq8yLXAw3pqIYZ25Edhb9pQErIAC+ednw40Cic6Le/h9ryph5/TqsvkOaUCw==
+  dependencies:
+    agent-base "^6.0.2"
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -2344,6 +2468,13 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -2420,6 +2551,21 @@ parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse5-htmlparser2-tree-adapter@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz#23c2cc233bcf09bb7beba8b8a69d46b08c62c2f1"
+  integrity sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==
+  dependencies:
+    domhandler "^5.0.2"
+    parse5 "^7.0.0"
+
+parse5@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.0.0.tgz#51f74a5257f5fcc536389e8c2d0b3802e1bfa91a"
+  integrity sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==
+  dependencies:
+    entities "^4.3.0"
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -2495,15 +2641,30 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-punycode@^2.1.0:
+psl@^1.1.33:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
+  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
+
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+rand-user-agent@^1.0.78:
+  version "1.0.78"
+  resolved "https://registry.yarnpkg.com/rand-user-agent/-/rand-user-agent-1.0.78.tgz#5472e954b06ab1ef8b7b080ebc0db6fd3a9a142d"
+  integrity sha512-atAfPjApMtpHK6pz+1zD1NYc8rV4ixqz4UtkYw17LSxKvOaaiLZBeUz6keJuTTNoTUjdYFZXAFBy29WHdvxwAw==
 
 react-is@^18.0.0:
   version "18.2.0"
@@ -2519,6 +2680,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -2751,6 +2917,16 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tough-cookie@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
+  integrity sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
 ts-jest@^28.0.8:
   version "28.0.8"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-28.0.8.tgz#cd204b8e7a2f78da32cf6c95c9a6165c5b99cc73"
@@ -2823,6 +2999,11 @@ typescript@^4.7.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 update-browserslist-db@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz#be06a5eedd62f107b7c19eb5bcefb194411abf38"
@@ -2837,6 +3018,14 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1220,7 +1220,14 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -1387,6 +1394,18 @@ eslint-config-prettier@^8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
+eslint-plugin-unused-imports@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
+  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
 eslint-scope@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
This serves as an example on how to obtain additional diasend data (like basal profile) from the diasend website instead of the API (since the API doesn't provide the desired data, also see #1).

Scraping is definitely not ideal as the website could change but I don't expect that to happen considering the switch to glooko at some point.

Either way, it can be used like:

```javascript
import { getPumpSettings, getAuthenticatedScrapingClient } from "./diasend";

const username = "my.user@diasend.com";
const password = "super-secret-password";

const { client, userId } = await getAuthenticatedScrapingClient({
  username, password
});

console.log(await getPumpSettings(client, userId));

>>> [
>>>  [ '00:00:00', 1.2 ],
>>>  [ '01:00:00', 0.8 ],
>>>  [ '05:00:00', 0.5 ],
>>>  [ '08:00:00', 0.3 ],
>>>  [ '11:00:00', 0.5 ],
>>>  [ '13:00:00', 0.6 ],
>>>  [ '15:00:00', 0.8 ],
>>>  [ '19:00:00', 1 ]
>>> ]
```