### PR TITLE
Import basal rate from diasend API

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,25 @@
         "${workspaceFolder}/dist/**/*.js"
       ],
       "envFile": "${workspaceFolder}/.env"
+    },
+    {
+      "type": "node",
+      "name": "vscode-jest-tests.v2",
+      "request": "launch",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "yarn",
+      "args": [
+        "test",
+        "--runInBand",
+        "--watchAll=false",
+        "--testNamePattern",
+        "${jest.testNamePattern}",
+        "--runTestsByPath",
+        "${jest.testFile}"
+      ]
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,3 @@
-{}
+{
+    "jest.jestCommandLine": "yarn test"
+}

--- a/__tests__/diasend-basal-to-nightscout-profile.ts
+++ b/__tests__/diasend-basal-to-nightscout-profile.ts
@@ -1,0 +1,46 @@
+import { updateBasalProfile } from "../adapter";
+import { BasalRecord } from "../diasend";
+import { TimeBasedValue, updateProfile } from "../nightscout";
+
+describe("testing conversion of diasend basal records to nightscout basal profile", () => {
+  test("conversion", () => {
+    // Given a bunch of basal records from diasend
+    // and an existing basal profile within nightscout
+    const basalRecords: BasalRecord[] = [
+      {
+        type: "insulin_basal",
+        created_at: "2022-09-16T07:25:12",
+        value: 1.5,
+        unit: "U/h",
+        flags: [],
+      },
+      {
+        type: "insulin_basal",
+        created_at: "2022-09-16T15:00:00",
+        value: 1.0,
+        unit: "U/h",
+        flags: [],
+      },
+    ];
+    const existingBasalProfile: TimeBasedValue[] = [
+      { value: 1.0, time: "00:00", timeAsSeconds: 0 },
+      { value: 1.2, time: "06:00", timeAsSeconds: 21600 },
+      { value: 0.8, time: "12:00", timeAsSeconds: 43200 },
+      { value: 0.6, time: "17:00", timeAsSeconds: 61200 },
+    ];
+
+    // when updating the nightscout profile
+    const updatedBasalProfile = updateBasalProfile(
+      existingBasalProfile,
+      basalRecords
+    );
+
+    // then expect historical data to be preserved but future data to be unknown (until the next update)
+    expect(updatedBasalProfile).toStrictEqual([
+      { value: 1, time: "00:00", timeAsSeconds: 0 },
+      { value: 1.2, time: "06:00", timeAsSeconds: 21600 },
+      { value: 1.5, time: "07:25:12", timeAsSeconds: 26712 },
+      { value: 1.0, time: "15:00", timeAsSeconds: 54000 },
+    ]);
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ import {
   getPumpSettings,
   getAuthenticatedScrapingClient,
   PumpSettings,
+  BasalRecord,
 } from "./diasend";
 import {
   reportEntriesToNightscout,
@@ -21,11 +22,13 @@ import {
   Profile,
   fetchProfile,
   updateProfile,
+  TimeBasedValue,
 } from "./nightscout";
 import {
   diasendBolusRecordToNightscoutTreatment,
   diasendGlucoseRecordToNightscoutEntry,
   diasendPumpSettingsToNightscoutProfile,
+  updateBasalProfile,
 } from "./adapter";
 
 dayjs.extend(relativeTime);
@@ -35,6 +38,7 @@ interface SyncDiasendDataToNightScoutArgs {
   diasendPassword?: string;
   diasendClientId?: string;
   diasendClientSecret?: string;
+  nightscoutProfileName?: string;
   nightscoutEntriesHandler?: (entries: Entry[]) => Promise<Entry[]>;
   nightscoutTreatmentsHandler?: (
     treatments: Treatment[]
@@ -48,13 +52,15 @@ async function syncDiasendDataToNightscout({
   diasendPassword = config.diasend.password,
   diasendClientId = config.diasend.clientId,
   diasendClientSecret = config.diasend.clientSecret,
-  nightscoutEntriesHandler = async (entries) =>
-    await reportEntriesToNightscout(entries),
-  nightscoutTreatmentsHandler = async (treatments) =>
-    await reportTreatmentsToNightscout(treatments),
+  nightscoutEntriesHandler = (entries) => reportEntriesToNightscout(entries),
+  nightscoutTreatmentsHandler = (treatments) =>
+    reportTreatmentsToNightscout(treatments),
+  nightscoutProfileName = config.nightscout.profileName!,
+  nightscoutProfileHandler = (profile) => updateProfile(profile),
+  nightscoutProfileLoader = () => fetchProfile(),
   dateFrom = dayjs().subtract(10, "minutes").toDate(),
   dateTo = new Date(),
-}: SyncDiasendDataToNightScoutArgs) {
+}: SyncDiasendDataToNightScoutArgs & NightscoutProfileOptions) {
   if (!diasendUsername) {
     throw Error("Diasend Username not configured");
   }
@@ -115,16 +121,38 @@ async function syncDiasendDataToNightscout({
           []
         );
 
+      // handle basal rates
+      const existingProfile = await nightscoutProfileLoader();
+      const existingProfileConfig =
+        existingProfile.store[nightscoutProfileName] || {};
+      const updatedBasalProfile = updateBasalProfile(
+        existingProfile.store[nightscoutProfileName].basal || [],
+        records.filter<BasalRecord>(
+          (record): record is BasalRecord => record.type === "insulin_basal"
+        )
+      );
+      const updatedProfile: Profile = {
+        ...existingProfile,
+        store: {
+          ...existingProfile.store,
+          [nightscoutProfileName]: {
+            ...existingProfileConfig,
+            basal: updatedBasalProfile,
+          },
+        },
+      };
+
       console.log(`Sending ${nightscoutEntries.length} entries to nightscout`);
       console.log(
         `Sending ${nightscoutTreatments.length} treatments to nightscout`
       );
       // send them to nightscout
-      const [entries, treatments] = await Promise.all([
+      const [entries, treatments, profile] = await Promise.all([
         nightscoutEntriesHandler(nightscoutEntries),
         nightscoutTreatmentsHandler(nightscoutTreatments),
+        nightscoutProfileHandler(updatedProfile),
       ]);
-      return { entries: entries ?? [], treatments: treatments ?? [] };
+      return { entries: entries ?? [], treatments: treatments ?? [], profile };
     })
   );
 
@@ -195,23 +223,28 @@ export function startSynchronization({
 
 let pumpSettingsSynchronizationTimeoutId: NodeJS.Timeout | undefined | number;
 
+type NightscoutProfileOptions = {
+  nightscoutProfileName?: string;
+  nightscoutProfileLoader?: () => Promise<Profile>;
+  nightscoutProfileHandler?: (profile: Profile) => Promise<Profile>;
+};
+
 export function startPumpSettingsSynchronization({
   diasendUsername = config.diasend.username,
   diasendPassword = config.diasend.password,
   // per default synchronize every 12 hours
   pollingIntervalMs = 12 * 3600 * 1000,
   nightscoutProfileName = config.nightscout.profileName,
-  nightscoutPumpSettingsHandler = (pumpSettings) =>
-    savePumpSettingsInNightscoutProfile(nightscoutProfileName!, pumpSettings),
+  nightscoutProfileLoader = async () => await fetchProfile(),
+  nightscoutProfileHandler = async (profile: Profile) =>
+    await updateProfile(profile),
+  importBasalRate = true,
 }: {
   diasendUsername?: string;
   diasendPassword?: string;
   pollingIntervalMs?: number;
-  nightscoutProfileName?: string;
-  nightscoutPumpSettingsHandler?: (
-    pumpSettings: PumpSettings
-  ) => Promise<Profile>;
-} = {}) {
+  importBasalRate?: boolean;
+} & NightscoutProfileOptions = {}) {
   function pumpSynchronizationLoop() {
     if (!diasendUsername) {
       throw Error("Diasend Username not configured");
@@ -232,7 +265,14 @@ export function startPumpSettingsSynchronization({
       password: diasendPassword,
     })
       .then(({ client, userId }) => getPumpSettings(client, userId))
-      .then(nightscoutPumpSettingsHandler)
+      .then(async (pumpSettings) =>
+        updateNightScoutProfileWithPumpSettings(
+          await nightscoutProfileLoader(),
+          pumpSettings,
+          { importBasalRate, nightscoutProfileName }
+        )
+      )
+      .then(nightscoutProfileHandler)
       .finally(() => {
         // restart after specified time
         // if synchronizationTimeoutId is set to 0 when we get here, don't schedule a re-run. This is the exit condition
@@ -257,18 +297,33 @@ export function startPumpSettingsSynchronization({
   };
 }
 
-async function savePumpSettingsInNightscoutProfile(
-  nightscoutProfileName: string,
-  pumpSettings: PumpSettings
-): Promise<Profile> {
-  const profile = await fetchProfile();
+function updateNightScoutProfileWithPumpSettings(
+  existingProfile: Profile,
+  pumpSettings: PumpSettings,
+  options: {
+    importBasalRate: boolean;
+    nightscoutProfileName: string;
+  } = {
+    importBasalRate: true,
+    nightscoutProfileName: config.nightscout.profileName!,
+  }
+): Profile {
+  const pumpSettingsAsProfileConfig =
+    diasendPumpSettingsToNightscoutProfile(pumpSettings);
 
-  return await updateProfile({
-    ...profile,
+  const previousProfileConfig =
+    existingProfile.store[options.nightscoutProfileName] || {};
+
+  return {
+    ...existingProfile,
     store: {
-      ...profile.store,
-      [nightscoutProfileName]:
-        diasendPumpSettingsToNightscoutProfile(pumpSettings),
+      ...existingProfile.store,
+      [options.nightscoutProfileName]: {
+        ...previousProfileConfig,
+        basal: options.importBasalRate
+          ? pumpSettingsAsProfileConfig.basal
+          : previousProfileConfig.basal,
+      },
     },
-  });
+  };
 }


### PR DESCRIPTION
With this PR, data records delivered by Diasend of the type `insulin_basal` will be imported into nightscout's basal profile.

![image](https://user-images.githubusercontent.com/6168665/190928529-77426342-2ebf-43a5-80cc-aecf7e4d0514.png)

**Important** Per default, the basal profile will be imported into a nightscout profile called "Diasend". This means, the default profile will not be overwritten and you'll need to manually select the Diasend profile within nightscout's _Profile Editor_: 
![image](https://user-images.githubusercontent.com/6168665/190927789-c8195ad7-52d1-40b4-a61c-cbf76cc030ca.png)

You can select which profile the data will be imported to by setting the environment variable `NIGHTSCOUT_PROFILE_NAME`. E.g. to import the basal rate into the _Default_ profile, set `NIGHTSCOUT_PROFILE_NAME=Default`. 

**Important 2** We already have a synchronization of basal profiles in place using the pump settings synchronization loop. To avoid the pump setting's basal rate to override the one provided by the diasend API, set `importBasalRate: false` for `startPumpSettingsSynchronization`.