### PR TITLE
[Fix] add rate to the tempbasal as this allows autotune to work

### DIFF
--- a/src/adapter/treatments.ts
+++ b/src/adapter/treatments.ts
@@ -47,6 +47,7 @@ export function diasendRecordToNightscoutTreatment(
     return {
       eventType: "Temp Basal",
       absolute: record.value,
+      rate: record.value,
       duration: defaultTempBasalDurationMinutes,
       ...baseTreatmentData,
     };

--- a/src/nightscout/types.ts
+++ b/src/nightscout/types.ts
@@ -109,7 +109,7 @@ export interface TempBasalTreatment extends Treatment {
   // ISO string timestamp for when the record or event occurred. Hard requirement for some events
   created_at: string;
   // Amount of insulin, if any. Given in Units per hour (U/h)
-  rate: number
+  rate?: number
 }
 
 export interface TimeBasedValue {

--- a/src/nightscout/types.ts
+++ b/src/nightscout/types.ts
@@ -108,6 +108,8 @@ export interface TempBasalTreatment extends Treatment {
   duration: number;
   // ISO string timestamp for when the record or event occurred. Hard requirement for some events
   created_at: string;
+  // Amount of insulin, if any. Given in Units per hour (U/h)
+  rate: number
 }
 
 export interface TimeBasedValue {


### PR DESCRIPTION
This PR adds rate to the TempBasal treatments because that allows the autotune website to work with this data.

<img width="1219" alt="Screenshot 2023-03-15 at 11 02 45 AM" src="https://user-images.githubusercontent.com/331436/225172738-90393f9f-f5c4-47c5-b0d6-2b1e0f267574.png">

The output of the autotune was useful.
